### PR TITLE
Automatically switch language

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -14,7 +14,7 @@ var game = {
     // navigator.language can include '-'
     // ref: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/language
     var requestLang = window.navigator.language.split('-')[0];
-    if (messages.languageActive.hasOwnProperty(requestLang)) {
+    if (window.location.hash === '' && requestLang !== 'en' && messages.languageActive.hasOwnProperty(requestLang)) {
       game.language = requestLang;
       window.location.hash = requestLang;
     }

--- a/js/game.js
+++ b/js/game.js
@@ -11,6 +11,13 @@ var game = {
   changed: false,
 
   start: function() {
+    // navigator.language can include '-'
+    // ref: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/language
+    var requestLang = window.navigator.language.split('-')[0];
+    if (messages.languageActive.hasOwnProperty(requestLang)) {
+      game.language = requestLang;
+      window.location.hash = requestLang;
+    }
     game.translate();
 
     $('#level-counter .total').text(levels.length);


### PR DESCRIPTION
This pull request enables to switch language automatically if `navigator.language` is in localizations. It avoids players from overlooking their language.