### PR TITLE
Fix "next" button not translating after load

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -42,7 +42,7 @@ var game = {
         return;
       }
 
-      $(this).removeClass();
+      $(this).removeClass('animated animation');
 
       $('.treatment').fadeOut(1000, 'linear', function() {
         $('.carrot, .weed').addClass('correct');
@@ -87,7 +87,7 @@ var game = {
     }).on('input', game.debounce(game.check, 200))
     .on('input', function() {
       game.changed = true;
-      $('#next').removeClass().addClass('disabled');
+      $('#next').removeClass('animated animation').addClass('disabled');
     });
 
     $('#editor').on('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function() {
@@ -215,7 +215,7 @@ var game = {
     $('#level-counter .current').text(this.level + 1);
     $('#before').text(level.before);
     $('#after').text(level.after);
-    $('#next').removeClass().addClass('disabled');
+    $('#next').removeClass('animated animation').addClass('disabled');
 
     var instructions = level.instructions[game.language] || level.instructions.en;
     $('#instructions').html(instructions);
@@ -363,7 +363,7 @@ var game = {
       }
 
       $('[data-level=' + game.level + ']').addClass('solved');
-      $('#next').removeClass().addClass('animated animation');
+      $('#next').removeClass('disabled').addClass('animated animation');
     } else {
       ga('send', {
         hitType: 'event',


### PR DESCRIPTION
First of all, thank you @thomaspark and contributors for the wonderful games 👏 

The changes in https://github.com/thomaspark/gridgarden/commit/2d042ca78f2abc68940e0415758c97cefafe5909 caused the "next" button to not be translated if you change the language after the page initially loads.

The page loaded in Dutch for me, but I prefer to play in English, which is how I noticed.

This PR changes the `removeClass()` calls without arguments (which remove all classes), to calls with arguments to only remove the required classes.

I plan on also submitting this change to Flexbox Froggy, which has the same issue.