### PR TITLE
Repressed spelling correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <div id="css">
           <div class="line-numbers">1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>10<br>11<br>12<br>13<br>14</div>
           <pre id="before"></pre>
-          <textarea id="code" autofocus autocapitalize="none"></textarea>
+          <textarea id="code" autofocus autocapitalize="none" spellcheck="false"></textarea>
           <pre id="after"></pre>
         </div>
         <button id="next" class="translate">Next</button>


### PR DESCRIPTION
Represses the spelling correction that occurs when changing languages. CSS code of the textarea is not the language chosen in the select menu in the footer, nor is it equivalent to <html lang=“something”> and should not show the user CSS correct codes as spelling mistakes as it does without this modification.
![image](https://github.com/user-attachments/assets/ebf91a43-22b0-4b94-b253-8bde98e05679)
